### PR TITLE
Fix main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "homepage": "https://github.com/Intracto/stylelint-config-intracto",
   "bugs": "https://github.com/Intracto/stylelint-config-intracto/issues",
-  "main": "js/index.js",
+  "main": "scss/index.js",
   "author": "Intracto <info@intracto.com> (https://www.intracto.com/)",
   "contributors": [
     {


### PR DESCRIPTION
`js/index.js` doesn't exist, not sure why this was added.