### PR TITLE
Update cosmiconfig docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn global add install-peerdeps
 install-peerdeps --dev "@intracto/stylelint-config-intracto"
 ```
 
-And then create a file `.stylelintrc.json`. Add this config if your codebase is based on SCSS:
+And then configure your [cosmiconfig](https://github.com/davidtheclark/cosmiconfig), e.g. by creating a `.stylelintrc.json` file with the following content:
 
 ```json
 {


### PR DESCRIPTION
Don't force people to use a `.stylelintrc.json` file, there are other options too.

> Add this config if your codebase is based on SCSS

There is no other option than SCSS, so this sentence is quite redundant.