### PR TITLE
Ditch contributers in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,6 @@
   "bugs": "https://github.com/Intracto/stylelint-config-intracto/issues",
   "main": "js/index.js",
   "author": "Intracto <info@intracto.com> (https://www.intracto.com/)",
-  "contributors": [
-    {
-      "name": "Yulian Alexeyev",
-      "url": "http://dev-q.be/",
-      "email": "yulian@dev-q.be"
-    }
-  ],
   "files": [
     "/scss"
   ],


### PR DESCRIPTION
Maintaining this can be a PITA, we have git to track the contributors.